### PR TITLE
fix(security): read MongoDB URI from environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,11 @@ npm-debug.*
 *.orig.*
 web-build/
 
+# Environment files
+.env
+.env.*
+!.env.example
+
 # macOS
 .DS_Store
 

--- a/Zen-backend/.env.example
+++ b/Zen-backend/.env.example
@@ -1,0 +1,2 @@
+MONGODB_URI=replace-with-mongodb-uri
+PORT=3000

--- a/Zen-backend/config/db.js
+++ b/Zen-backend/config/db.js
@@ -1,8 +1,13 @@
 const mongoose = require('mongoose');
+const MONGODB_URI = process.env.MONGODB_URI;
 
 const connectDB = async () => {
     try {
-        await mongoose.connect("mongodb+srv://sachilaawandya:sachila20000816@habit-cluster.cldoa.mongodb.net/?retryWrites=true&w=majority&appName=habit-cluster", {
+        if (!MONGODB_URI) {
+            throw new Error('MONGODB_URI environment variable is required');
+        }
+
+        await mongoose.connect(MONGODB_URI, {
             useNewUrlParser: true,
             useUnifiedTopology: true,
         });

--- a/Zen-backend/server.js
+++ b/Zen-backend/server.js
@@ -4,11 +4,14 @@ const app = express();
 const cors = require("cors");
 const habits = require("./routes/habitRoutes");
 const users = require("./routes/userRoutes");
+const MONGODB_URI = process.env.MONGODB_URI;
+
+if (!MONGODB_URI) {
+  throw new Error("MONGODB_URI environment variable is required");
+}
 
 mongoose
-  .connect(
-    "mongodb+srv://sachilaawandya:sachila20000816@habit-cluster.cldoa.mongodb.net/?retryWrites=true&w=majority&appName=habit-cluster"
-  )
+  .connect(MONGODB_URI)
   .then(() => console.log("Connect to MongoDB"))
   .catch((err) => console.log("Could not connect to MongoDB", err));
 


### PR DESCRIPTION
## Summary

- Read `MONGODB_URI` from the environment in both backend connection paths.
- Fail clearly when the variable is missing.
- Add a non-secret `.env.example` and ignore real environment files.

## Verification

- `node --check Zen-backend/config/db.js`
- `node --check Zen-backend/server.js`
- No MongoDB URI literal remains in the changed files.
- `.env` is ignored while `.env.example` remains trackable.